### PR TITLE
Add RFC8599 test for Push Notification on REGISTER

### DIFF
--- a/sipp_uac_register_pns_non-push.xml
+++ b/sipp_uac_register_pns_non-push.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Per RFC8599 Section 4.1.4 Figure 3 Part 1 - Non-Push Notification on Register using Contact header -->
+
+<scenario name="registration">
+
+<send retrans="500">
+<![CDATA[
+REGISTER sip:[field1] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: "sipp" <sip:[field0]@[field1]>;tag=[call_number]
+To: "sipp" <sip:[field0]@[field1]>
+Call-ID: reg///[call_id]
+CSeq: 7 REGISTER
+Contact: <sip:sipp@[local_ip]:[local_port];pn-provider=acme;pn-param=acme-param;pn-prid=acme-psn-user-[field0]>;+sip.pnsreg
+Expires: 3600
+Content-Length: 0
+User-Agent: SIPp
+]]>
+</send>
+
+<recv response="100" optional="true">
+</recv>
+
+<recv response="401" auth="true" rtd="true">
+</recv>
+
+<send retrans="500">
+<![CDATA[
+REGISTER sip:[field1] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: "sipp" <sip:[field0]@[field1]>;tag=[call_number]
+To: "sipp" <sip:[field0]@[field1]>
+Call-ID: reg///[call_id]
+CSeq: 8 REGISTER
+Contact: <sip:sipp@[local_ip]:[local_port];pn-provider=acme;pn-param=acme-param;pn-prid=acme-psn-user-[field0]>;+sip.pnsreg
+Expires: 3600
+Content-Length: 0
+User-Agent: SIPp
+[field2]
+]]>
+</send>
+
+<recv response="100" optional="true">
+</recv>
+
+<recv response="200">
+</recv>
+
+<ResponseTimeRepartition value="10, 20"/>
+<CallLengthRepartition value="10"/>
+</scenario>
+

--- a/sipp_uac_register_pns_non-push_fc.xml
+++ b/sipp_uac_register_pns_non-push_fc.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Per RFC8599 Section 4.1.4 Figure 3 Part 2 - Non-Push Notification on Register using Feature-Caps header -->
+
+<scenario name="registration">
+
+<send retrans="500">
+<![CDATA[
+REGISTER sip:[field1] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: "sipp" <sip:[field0]@[field1]>;tag=[call_number]
+To: "sipp" <sip:[field0]@[field1]>
+Call-ID: reg///[call_id]
+CSeq: 7 REGISTER
+Contact: <sip:sipp@[local_ip]:[local_port];pn-provider=acme;pn-param=acme-param;pn-prid=acme-psn-user-[field0]>;+sip.pnsreg
+Feature-Caps: *;+sip.pns="acme";+sip.pnsreg="121"	
+Expires: 3600
+Content-Length: 0
+User-Agent: SIPp
+]]>
+</send>
+
+<recv response="100" optional="true">
+</recv>
+
+<recv response="401" auth="true" rtd="true">
+</recv>
+
+<send retrans="500">
+<![CDATA[
+REGISTER sip:[field1] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: "sipp" <sip:[field0]@[field1]>;tag=[call_number]
+To: "sipp" <sip:[field0]@[field1]>
+Call-ID: reg///[call_id]
+CSeq: 8 REGISTER
+Contact: <sip:sipp@[local_ip]:[local_port];pn-provider=acme;pn-param=acme-param;pn-prid=acme-psn-user-[field0]>;+sip.pnsreg
+Feature-Caps: *;+sip.pns="acme";+sip.pnsreg="121"	
+Expires: 3600
+Content-Length: 0
+User-Agent: SIPp
+[field2]
+]]>
+</send>
+
+<recv response="100" optional="true">
+</recv>
+
+<recv response="200">
+</recv>
+
+<ResponseTimeRepartition value="10, 20"/>
+<CallLengthRepartition value="10"/>
+</scenario>
+

--- a/sipp_uac_register_pns_push.xml
+++ b/sipp_uac_register_pns_push.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Per RFC8599 Figure 2 -->
+<!-- Per RFC8599 Section 1 Figure 2 - Push Notification on Register using Contact header -->
+
+<scenario name="registration">
+
+<send retrans="500">
+<![CDATA[
+REGISTER sip:[field1] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: "sipp" <sip:[field0]@[field1]>;tag=[call_number]
+To: "sipp" <sip:[field0]@[field1]>
+Call-ID: reg///[call_id]
+CSeq: 7 REGISTER
+Contact: <sip:sipp@[local_ip]:[local_port];pn-provider=acme;pn-param=acme-param;pn-prid=acme-psn-user-[field0]>
+Expires: 3600
+Content-Length: 0
+User-Agent: SIPp
+]]>
+</send>
+
+<recv response="100" optional="true">
+</recv>
+
+<recv response="401" auth="true" rtd="true">
+</recv>
+
+<send retrans="500">
+<![CDATA[
+REGISTER sip:[field1] SIP/2.0
+Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+Max-Forwards: 70
+From: "sipp" <sip:[field0]@[field1]>;tag=[call_number]
+To: "sipp" <sip:[field0]@[field1]>
+Call-ID: reg///[call_id]
+CSeq: 8 REGISTER
+Contact: <sip:sipp@[local_ip]:[local_port];pn-provider=acme;pn-param=acme-param;pn-prid=acme-psn-user-[field0]>
+Expires: 3600
+Content-Length: 0
+User-Agent: SIPp
+[field2]
+]]>
+</send>
+
+<recv response="100" optional="true">
+</recv>
+
+<recv response="200">
+</recv>
+
+<ResponseTimeRepartition value="10, 20"/>
+<CallLengthRepartition value="10"/>
+</scenario>
+


### PR DESCRIPTION
Cloned sip_register_uac.xml into three separate tests for each of the three example figures provided in RFC8599 for Push Notification Server interaction:

1. Push with PNS info in Contact of REGISTER (per RFC8599 Figure 2)
2. Non-Push with PNS info in Contact of REGISTER (per RFC8599 Figure 3 Part 1)
3. Non-Push with PNS info in Contact and Feature-Caps of REGISTER (per RFC8599 Figure 3 Part 2)

Resolves: #11